### PR TITLE
feat(#16): Supporting last image as idle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 venv
 .env
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN python3.11 -m ensurepip
 # Unbuffered logging
 ENV PYTHONUNBUFFERED=TRUE
 
-COPY idle.mp4 requirements.txt ./
+COPY idle.mp4 eye.png requirements.txt ./
 
 RUN pip3.11 install -U --upgrade-strategy eager -r requirements.txt
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ PYAARLO_STORAGE_DIR: Pyaarlo storage_dir. Define it if you want to change the Py
 PYAARLO_ECDH_CURVE: Allowing you defining the ECDH CURVE to use during pyaarlo authentication
 IMAP_GRAB_ALL: Grabs all mails in the inbox, to avoid slow indexing problems (default: False)
 LAST_IMAGE_IDLE: Set last frame as idle image for the camera (default: False)
+DEFAULT_RESOLUTION: Default resolution for the idle video (default: (1280, 768))
 ```
 ### Running
 ```

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ PYAARLO_STREAM_TIMEOUT: Pyaarlo backend event stream timeout (in seconds) (defau
 PYAARLO_STORAGE_DIR: Pyaarlo storage_dir. Define it if you want to change the Pyaarlo storage directory. (default determined by pyaarlo)
 PYAARLO_ECDH_CURVE: Allowing you defining the ECDH CURVE to use during pyaarlo authentication
 IMAP_GRAB_ALL: Grabs all mails in the inbox, to avoid slow indexing problems (default: False)
+IMAP_DELETE_AFTER: Deletes mail after extracting code for 2fa (default: False)
 LAST_IMAGE_IDLE: Set last frame as idle image for the camera (default: False)
 DEFAULT_RESOLUTION: Default resolution for the idle video (default: (1280, 768))
 ```

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ PYAARLO_STREAM_TIMEOUT: Pyaarlo backend event stream timeout (in seconds) (defau
 PYAARLO_STORAGE_DIR: Pyaarlo storage_dir. Define it if you want to change the Pyaarlo storage directory. (default determined by pyaarlo)
 PYAARLO_ECDH_CURVE: Allowing you defining the ECDH CURVE to use during pyaarlo authentication
 IMAP_GRAB_ALL: Grabs all mails in the inbox, to avoid slow indexing problems (default: False)
+LAST_IMAGE_IDLE: Set last frame as idle image for the camera (default: False)
 ```
 ### Running
 ```

--- a/camera.py
+++ b/camera.py
@@ -165,6 +165,9 @@ class Camera(Device):
         
         # Using last camera's thumbnail as idle stream if exists
         if last_image:
+            logging.debug(
+                f"Last image found for {self.name}, setting as idle"
+            )
             # Converting last_image to a video for loop_stream (less CPU consumsion)
             convert = await asyncio.create_subprocess_exec(
                 *['ffmpeg', '-y',

--- a/camera.py
+++ b/camera.py
@@ -5,7 +5,7 @@ import shlex
 import os
 from device import Device
 from decouple import config
-from pyaarlo.util import http_get
+from utils import download_file
 
 DEBUG = config('DEBUG', default=False, cast=bool)
 
@@ -164,9 +164,10 @@ class Camera(Device):
                     ]
 
         if self.last_image_idle:
-            image_path = "/tmp/{}.jpg".format(self.name)
-            last_image = http_get(self._arlo.last_image, filename=image_path)
-
+            image_path = f"/tmp/{self.name}.jpg"
+            last_image = await download_file(
+                self._arlo.last_image, image_path
+                )
             # Using last camera's thumbnail as idle stream if exists
             if last_image:
                 logging.debug(

--- a/camera.py
+++ b/camera.py
@@ -30,10 +30,11 @@ class Camera(Device):
     STATES = ['idle', 'streaming']
 
     def __init__(self, arlo_camera, ffmpeg_out,
-                 motion_timeout, status_interval):
+                 motion_timeout, status_interval, last_image_idle):
         super().__init__(arlo_camera, status_interval)
         self.ffmpeg_out = shlex.split(ffmpeg_out.format(name=self.name))
         self.timeout = motion_timeout
+        self.last_image_idle = last_image_idle
         self._timeout_task = None
         self.motion = False
         self._state = None
@@ -162,40 +163,41 @@ class Camera(Device):
                     '-bsf', 'dump_extra', '-f', 'mpegts', 'pipe:'
                     ]
 
-        image_path = "/tmp/{}.jpg".format(self.name)
-        last_image = http_get(self._arlo.last_image, filename=image_path)
+        if self.last_image_idle:
+            image_path = "/tmp/{}.jpg".format(self.name)
+            last_image = http_get(self._arlo.last_image, filename=image_path)
 
-        # Using last camera's thumbnail as idle stream if exists
-        if last_image:
-            logging.debug(
-                f"Last image found for {self.name}, setting as idle"
-            )
-            # Converting last_image to a video for loop_stream (less CPU usage)
-            convert = await asyncio.create_subprocess_exec(
-                *['ffmpeg', '-y',
-                  '-framerate', '1',
-                  '-i', image_path,
-                  '-c:v', 'libx264', '-r', '30', '-vf', 'scale=640:-2',
-                  "/tmp/{}.mp4".format(self.name)],
-                stdin=subprocess.DEVNULL,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE if DEBUG else subprocess.DEVNULL
+            # Using last camera's thumbnail as idle stream if exists
+            if last_image:
+                logging.debug(
+                    f"Last image found for {self.name}, setting as idle"
                 )
-
-            if DEBUG:
-                asyncio.create_task(
-                    self._log_stderr(convert, 'idle_stream')
+                # Converting last_image to a video for loop_stream
+                convert = await asyncio.create_subprocess_exec(
+                    *['ffmpeg', '-y',
+                      '-framerate', '1',
+                      '-i', image_path,
+                      '-c:v', 'libx264', '-r', '30', '-vf', 'scale=640:-2',
+                      "/tmp/{}.mp4".format(self.name)],
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE if DEBUG else subprocess.DEVNULL
                     )
 
-            convert_exit_code = await convert.wait()
-            if convert_exit_code == 0:
-                idle_stream_command = [
-                    'ffmpeg',
-                    '-re', '-stream_loop', '-1',
-                    '-i', "/tmp/{}.mp4".format(self.name),
-                    '-c:v', 'copy', '-shortest',
-                    '-f', 'mpegts', 'pipe:'
-                    ]
+                if DEBUG:
+                    asyncio.create_task(
+                        self._log_stderr(convert, 'idle_stream')
+                        )
+
+                convert_exit_code = await convert.wait()
+                if convert_exit_code == 0:
+                    idle_stream_command = [
+                        'ffmpeg',
+                        '-re', '-stream_loop', '-1',
+                        '-i', "/tmp/{}.mp4".format(self.name),
+                        '-c:v', 'copy', '-shortest',
+                        '-f', 'mpegts', 'pipe:'
+                        ]
 
         while exit_code > 0:
             self.stream = await asyncio.create_subprocess_exec(

--- a/camera.py
+++ b/camera.py
@@ -334,7 +334,7 @@ class Camera(Device):
             *['ffmpeg', '-loop', '1', '-i', image_path,
               '-f', 'lavfi', '-i', 'anullsrc=r=16000:cl=mono',
               '-c:v', 'libx264', '-c:a', 'mp2', '-t', '5',
-              '-pix_fmt', 'yuv420p', '-r', '24', '-vf',
+              '-pix_fmt', 'yuv420p', '-r', '24', '-g', '24', '-vf',
               f"scale={self.resolution[0]}:{self.resolution[1]}",
               '-f', 'mpegts', '-y', output_path],
             stdin=subprocess.DEVNULL,

--- a/camera.py
+++ b/camera.py
@@ -386,7 +386,6 @@ class Camera(Device):
         while True:
             try:
                 line = await stream.stderr.readline()
-
                 if line:
                     logging.debug(
                         f"{self.name} - {label}: {line.decode().strip()}"

--- a/camera.py
+++ b/camera.py
@@ -167,7 +167,7 @@ class Camera(Device):
         if last_image:
             # Converting last_image to a video for loop_stream (less CPU consumsion)
             convert = await asyncio.create_subprocess_exec(
-                *['ffmpeg',
+                *['ffmpeg', '-y',
                   '-framerate', '1',
                   '-i', image_path,
                   '-c:v', 'libx264', '-r', '30', '-vf', 'scale=640:-2', "/tmp/{}.mp4".format(self.name)

--- a/device.py
+++ b/device.py
@@ -23,7 +23,6 @@ class Device(object):
         Creates event channel between pyaarlo callbacks and async generator.
         Listens for and passes events to handler.
         """
-        self.event_loop = asyncio.get_running_loop()
         event_get, event_put = self.create_sync_async_channel()
         self._arlo.add_attr_callback('*', event_put)
         asyncio.create_task(self._periodic_status_trigger())

--- a/main.py
+++ b/main.py
@@ -15,9 +15,10 @@ IMAP_PASS = config('IMAP_PASS')
 IMAP_GRAB_ALL = config('IMAP_GRAB_ALL', default=False)
 MQTT_BROKER = config('MQTT_BROKER', default=None)
 FFMPEG_OUT = config('FFMPEG_OUT')
+DEFAULT_RESOLUTION = config('DEFAULT_RESOLUTION', default=(1280, 768))
 MOTION_TIMEOUT = config('MOTION_TIMEOUT', default=60, cast=int)
 STATUS_INTERVAL = config('STATUS_INTERVAL', default=120, cast=int)
-LAST_IMAGE_IDLE = config('LAST_IMAGE_IDLE', default=False)
+LAST_IMAGE_IDLE = config('LAST_IMAGE_IDLE', default=False, cast=bool)
 DEBUG = config('DEBUG', default=False, cast=bool)
 PYAARLO_BACKEND = config('PYAARLO_BACKEND', default=None)
 PYAARLO_REFRESH_DEVICES = config('PYAARLO_REFRESH_DEVICES', default=0, cast=int)
@@ -69,7 +70,8 @@ async def main():
 
     # Initialize cameras
     cameras = [Camera(
-        c, FFMPEG_OUT, MOTION_TIMEOUT, STATUS_INTERVAL, LAST_IMAGE_IDLE
+        c, FFMPEG_OUT, MOTION_TIMEOUT, STATUS_INTERVAL, LAST_IMAGE_IDLE,
+        DEFAULT_RESOLUTION
         ) for c in arlo.cameras]
 
     # Start both

--- a/main.py
+++ b/main.py
@@ -12,7 +12,8 @@ ARLO_PASS = config('ARLO_PASS')
 IMAP_HOST = config('IMAP_HOST')
 IMAP_USER = config('IMAP_USER')
 IMAP_PASS = config('IMAP_PASS')
-IMAP_GRAB_ALL = config('IMAP_GRAB_ALL', default=False)
+IMAP_GRAB_ALL = config('IMAP_GRAB_ALL', default=False, cast=bool)
+IMAP_DELETE_AFTER = config('IMAP_DELETE_AFTER', default=False, cast=bool)
 MQTT_BROKER = config('MQTT_BROKER', default=None)
 FFMPEG_OUT = config('FFMPEG_OUT')
 DEFAULT_RESOLUTION = config('DEFAULT_RESOLUTION', default=(1280, 768))
@@ -45,7 +46,8 @@ async def main():
         'tfa_host': IMAP_HOST,
         'tfa_username': IMAP_USER,
         'tfa_password': IMAP_PASS,
-        'tfa_grab_all': IMAP_GRAB_ALL
+        'tfa_grab_all': IMAP_GRAB_ALL,
+        'tfa_delete_after': IMAP_DELETE_AFTER
     }
 
     if PYAARLO_REFRESH_DEVICES:

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ MQTT_BROKER = config('MQTT_BROKER', default=None)
 FFMPEG_OUT = config('FFMPEG_OUT')
 MOTION_TIMEOUT = config('MOTION_TIMEOUT', default=60, cast=int)
 STATUS_INTERVAL = config('STATUS_INTERVAL', default=120, cast=int)
+LAST_IMAGE_IDLE = config('LAST_IMAGE_IDLE', default=False)
 DEBUG = config('DEBUG', default=False, cast=bool)
 PYAARLO_BACKEND = config('PYAARLO_BACKEND', default=None)
 PYAARLO_REFRESH_DEVICES = config('PYAARLO_REFRESH_DEVICES', default=0, cast=int)
@@ -68,7 +69,7 @@ async def main():
 
     # Initialize cameras
     cameras = [Camera(
-        c, FFMPEG_OUT, MOTION_TIMEOUT, STATUS_INTERVAL
+        c, FFMPEG_OUT, MOTION_TIMEOUT, STATUS_INTERVAL, LAST_IMAGE_IDLE
         ) for c in arlo.cameras]
 
     # Start both

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ git+https://github.com/kaffetorsk/pyaarlo@grab_all
 python-decouple
 aiomqtt==1.2.1
 aiostream
+aiohttp

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,17 @@
+import aiohttp
+
+
+async def download_file(url, dest_filename):
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as response:
+            if response.status == 200:
+                # Read file data
+                with open(dest_filename, 'wb') as f:
+                    while True:
+                        chunk = await response.content.read(1024)
+                        if not chunk:
+                            break
+                        f.write(chunk)
+                return True
+            else:
+                return False


### PR DESCRIPTION
I worked on the issue #16 

It uses http_get pyaarlo's function to retrieve de last image/thumbnail, convert the image to a video file, and stream it in a loop.
If no image is found, fallback to the original idle stream.

Why converting the image to a video file ? Because I didn't find a good way to stream the image directly. Streaming a image cause cpu load around 30%.