### PR TITLE
2fa fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ PYAARLO_REFRESH_DEVICES: Pyaarlo backend device refresh interval (in hours) (def
 PYAARLO_STREAM_TIMEOUT: Pyaarlo backend event stream timeout (in seconds) (default: never)
 PYAARLO_STORAGE_DIR: Pyaarlo storage_dir. Define it if you want to change the Pyaarlo storage directory. (default determined by pyaarlo)
 PYAARLO_ECDH_CURVE: Allowing you defining the ECDH CURVE to use during pyaarlo authentication
+IMAP_GRAB_ALL: Grabs all mails in the inbox, to avoid slow indexing problems (default: False)
 ```
 ### Running
 ```

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ ARLO_PASS = config('ARLO_PASS')
 IMAP_HOST = config('IMAP_HOST')
 IMAP_USER = config('IMAP_USER')
 IMAP_PASS = config('IMAP_PASS')
+IMAP_GRAB_ALL = config('IMAP_GRAB_ALL', default=False)
 MQTT_BROKER = config('MQTT_BROKER', default=None)
 FFMPEG_OUT = config('FFMPEG_OUT')
 MOTION_TIMEOUT = config('MOTION_TIMEOUT', default=60, cast=int)
@@ -41,7 +42,8 @@ async def main():
         'tfa_type': 'email',
         'tfa_host': IMAP_HOST,
         'tfa_username': IMAP_USER,
-        'tfa_password': IMAP_PASS
+        'tfa_password': IMAP_PASS,
+        'tfa_grab_all': IMAP_GRAB_ALL
     }
 
     if PYAARLO_REFRESH_DEVICES:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/twrecked/pyaarlo
+git+https://github.com/kaffetorsk/pyaarlo@grab_all
 python-decouple
 aiomqtt==1.2.1
 aiostream


### PR DESCRIPTION
Fix to pyaarlo to grab all emails instead of searching for arlo mails.

This fixes an issue with some imap servers being slow to index.

Enable by setting:
```
IMAP_GRAB_ALL=True
```