### PR TITLE
Fix issue with remote stream activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ This allow arlo cameras to be used in the NVR of your choosing. (e.g. [Frigate](
 The streams will provide an "idle" picture when the camera is not actively streaming.
 Motion will trigger an active stream, replacing the "idle" picture with the actual camera stream.
 
+External streams (typically live view in arlo app) will trigger a watch mode. Due to limitations in pyaarlo this kind of stream will have to be periodically taken down and restablished to see if the stream is still beeing viewed elsewhere.
+
+
 **Note:** For ideal operation, the arlo cameras should not be set to record on motion in the arlo app. This slows down stream setup significantly, leading to loss of valuable frames at the start of the event. A common approach is to choose push notification only, then disable notifications for the arlo app.
 
 ## Usage
@@ -25,7 +28,7 @@ FFMPEG_OUT: out-string for ffmpeg. (e.g. -c:v copy -c:a copy -f flv rtmp://127.0
 ```
 ### Optional
 ```
-MOTION_TIMEOUT: How long to provide active stream after motion (in seconds) (default: 60)
+MOTION_TIMEOUT: How long to provide active stream after motion (in seconds). Also used as refresh interval for external streams (default: 60)
 MQTT_BROKER: If specified, will be used to publish snapshots and status, and control the camera (see MQTT).
 MQTT_PORT: broker port (default: 1883)
 MQTT_USER: broker username. Not setting this will result in an anonymous connection (default: None)
@@ -36,6 +39,7 @@ MQTT_TOPIC_CONTROL: control will be read on this topic. (default: arlo/control/{
 MQTT_TOPIC_MOTION: motion events will be published to this topic. (default: arlo/motion/{name})
 MQTT_RECONNECT_INTERVAL: Wait this amount before retrying connection to broker (in seconds) (default: 5)
 STATUS_INTERVAL: Time between published status messages (in seconds) (default: 120)
+WATCH_REFRESH_TIME: Downtime to check if remote stream is still active (in seconds) (default: 2)
 DEBUG: True enables full debug (default: False)
 PYAARLO_BACKEND: Pyaarlo backend. (default determined by pyaarlo). Options are `mqtt` and `sse`.
 PYAARLO_REFRESH_DEVICES: Pyaarlo backend device refresh interval (in hours) (default: never)

--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ DEFAULT_RESOLUTION = config('DEFAULT_RESOLUTION', default=(1280, 768))
 MOTION_TIMEOUT = config('MOTION_TIMEOUT', default=60, cast=int)
 STATUS_INTERVAL = config('STATUS_INTERVAL', default=120, cast=int)
 LAST_IMAGE_IDLE = config('LAST_IMAGE_IDLE', default=False, cast=bool)
+WATCH_REFRESH_TIME = config('WATCH_REFRESH_TIME', default=2, cast=int)
 DEBUG = config('DEBUG', default=False, cast=bool)
 PYAARLO_BACKEND = config('PYAARLO_BACKEND', default=None)
 PYAARLO_REFRESH_DEVICES = config('PYAARLO_REFRESH_DEVICES', default=0, cast=int)
@@ -73,7 +74,7 @@ async def main():
     # Initialize cameras
     cameras = [Camera(
         c, FFMPEG_OUT, MOTION_TIMEOUT, STATUS_INTERVAL, LAST_IMAGE_IDLE,
-        DEFAULT_RESOLUTION
+        DEFAULT_RESOLUTION, WATCH_REFRESH_TIME
         ) for c in arlo.cameras]
 
     # Start both

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/kaffetorsk/pyaarlo@grab_all
+git+https://github.com/kaffetorsk/pyaarlo@live
 python-decouple
 aiomqtt==1.2.1
 aiostream


### PR DESCRIPTION
Added `watching` state to camera. This is set when something else than arlo-streamer activates a stream.

Fixes Issue #26 